### PR TITLE
Add file selector module

### DIFF
--- a/modules/file-selector/index.test.ts
+++ b/modules/file-selector/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fileSelector from './index';
+
+describe('file-selector run', () => {
+  let originalDocument: any;
+
+  beforeEach(() => {
+    originalDocument = global.document;
+  });
+
+  afterEach(() => {
+    global.document = originalDocument;
+    vi.restoreAllMocks();
+  });
+
+  it('returns selected file paths', async () => {
+    const fakeInput: any = {
+      type: '',
+      multiple: false,
+      files: [{ path: '/tmp/test.txt', name: 'test.txt' }],
+      onchange: undefined as ((e: any) => void) | undefined,
+      click() {
+        if (this.onchange) this.onchange({ target: this });
+      },
+    };
+
+    const createElement = vi.fn(() => fakeInput);
+    global.document = { createElement } as any;
+
+    const paths = await fileSelector.run();
+    expect(createElement).toHaveBeenCalledWith('input');
+    expect(paths).toEqual(['/tmp/test.txt']);
+  });
+});

--- a/modules/file-selector/index.ts
+++ b/modules/file-selector/index.ts
@@ -1,0 +1,36 @@
+export interface FileSelectorModule {
+  id: string;
+  version: string;
+  name: string;
+  description: string;
+  inputs: Record<string, unknown>;
+  outputs: Record<string, unknown>;
+  uiSchema: Record<string, unknown>;
+  run: () => Promise<string[]>;
+}
+
+const module: FileSelectorModule = {
+  id: 'file-selector',
+  version: '1.0.0',
+  name: 'File Selector',
+  description: 'Prompts the user to select files',
+  inputs: {},
+  outputs: {},
+  uiSchema: {},
+  async run() {
+    return new Promise<string[]>((resolve) => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.multiple = true;
+      input.onchange = () => {
+        const files = Array.from(input.files ?? []).map(
+          (f) => (f as any).path ?? f.name
+        );
+        resolve(files);
+      };
+      input.click();
+    });
+  },
+};
+
+export default module;


### PR DESCRIPTION
## Summary
- implement `modules/file-selector` with module metadata and `run` function
- add unit test for `run()` behavior

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6846dc449dcc832581e8b42c9b0395df