### PR TITLE
Implement text-input module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/modules/text-input/index.ts
+++ b/modules/text-input/index.ts
@@ -1,0 +1,15 @@
+export default {
+  name: 'text-input',
+  version: '1.0.0',
+  description: 'Free text entry module',
+  uiSchema: {
+    type: 'object',
+    properties: {
+      text: { type: 'string', title: 'Text' }
+    },
+    required: ['text']
+  },
+  async run(input: { text: string }): Promise<string> {
+    return input.text;
+  }
+};

--- a/packages/core/test/textInputModule.test.ts
+++ b/packages/core/test/textInputModule.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { loadModules } from '../src/index';
+
+describe('text-input module', () => {
+  it('runs and returns entered text', async () => {
+    const modules = await loadModules();
+    const mod: any = modules.find(m => m.name === 'text-input');
+    expect(mod).toBeDefined();
+    const result = await mod.run({ text: 'hello' });
+    expect(result).toBe('hello');
+  });
+});


### PR DESCRIPTION
## Summary
- add `.gitignore`
- implement `text-input` module exporting metadata, uiSchema, and `run` method
- test that text-input module loads and returns input text

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6846dc46a3ac832595d861bbbc8e8180