### PR TITLE
Add logger module with console output

### DIFF
--- a/modules/logger/index.ts
+++ b/modules/logger/index.ts
@@ -1,0 +1,22 @@
+export interface LoggerOptions {
+  prefix?: string;
+}
+
+export default {
+  name: 'logger',
+  version: '1.0.0',
+  description: 'Logs string input to console',
+  uiSchema: {
+    type: 'object',
+    properties: {
+      prefix: { type: 'string', title: 'Prefix' }
+    },
+    required: []
+  },
+  async run(input: string, options: LoggerOptions = {}): Promise<string> {
+    const prefix = options.prefix ?? '';
+    // eslint-disable-next-line no-console
+    console.log(prefix + input);
+    return input;
+  }
+};

--- a/packages/core/test/logger.test.ts
+++ b/packages/core/test/logger.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { loadModules } from '../src/index';
+
+describe('logger module', () => {
+  it('logs input with optional prefix', async () => {
+    const modules = await loadModules();
+    const logger: any = modules.find(m => m.name === 'logger');
+    expect(logger).toBeDefined();
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await logger.run('test', { prefix: '[pref] ' });
+
+    expect(spy).toHaveBeenCalledWith('[pref] test');
+    expect(result).toBe('test');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- implement logger module under `modules/logger`
- include optional prefix via `uiSchema`
- add unit test verifying logger module loads and logs with prefix

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6846dc49383883259dd180e0e562e214