### PR TITLE
Add text-input module metadata test

### DIFF
--- a/packages/core/test/textInputModule.test.ts
+++ b/packages/core/test/textInputModule.test.ts
@@ -6,6 +6,9 @@ describe('text-input module', () => {
     const modules = await loadModules();
     const mod: any = modules.find(m => m.name === 'text-input');
     expect(mod).toBeDefined();
+    expect(mod.uiSchema).toBeDefined();
+    expect(mod.uiSchema.properties.text.type).toBe('string');
+    expect(mod.uiSchema.required).toContain('text');
     const result = await mod.run({ text: 'hello' });
     expect(result).toBe('hello');
   });


### PR DESCRIPTION
## Summary
- check text-input module `uiSchema` in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847d71c10dc8325b8c464199cc95812