### PR TITLE
Implement file selector metadata

### DIFF
--- a/modules/file-selector/index.ts
+++ b/modules/file-selector/index.ts
@@ -1,10 +1,12 @@
+import uiSchema from './uiSchema.json';
+
 export interface FileSelectorModule {
   id: string;
   version: string;
   name: string;
   description: string;
-  inputs: Record<string, unknown>;
-  outputs: Record<string, unknown>;
+  inputs: string[];
+  outputs: string[];
   uiSchema: Record<string, unknown>;
   run: () => Promise<string[]>;
 }
@@ -14,9 +16,9 @@ const module: FileSelectorModule = {
   version: '1.0.0',
   name: 'File Selector',
   description: 'Prompts the user to select files',
-  inputs: {},
-  outputs: {},
-  uiSchema: {},
+  inputs: [],
+  outputs: ['paths'],
+  uiSchema,
   async run() {
     return new Promise<string[]>((resolve) => {
       const input = document.createElement('input');

--- a/modules/file-selector/uiSchema.json
+++ b/modules/file-selector/uiSchema.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "title": "File Selector Options",
+  "properties": {},
+  "required": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]


### PR DESCRIPTION
## Summary
- add uiSchema JSON for file selector module
- import uiSchema and expose metadata
- enable JSON module resolution in TypeScript config

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6847d71b58288325bc5678b56a598563