### PR TITLE
Add React Flow editing helpers

### DIFF
--- a/apps/builder/test/flow.test.ts
+++ b/apps/builder/test/flow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createNode, isConnectionValid } from '../src/flow';
+import { createNode, isConnectionValid, validateConnection } from '../src/flow';
 import type { ModuleMetadata } from '@toolbox/core';
 
 const modA: ModuleMetadata & { outputs: string[] } = { name: 'A', version: '1', outputs: ['text'] } as any;
@@ -25,5 +25,27 @@ describe('isConnectionValid', () => {
     const a = { module: modA };
     const c = { module: modC };
     expect(isConnectionValid(a, c)).toBe(false);
+  });
+});
+
+describe('validateConnection', () => {
+  const nodeA = createNode(modA);
+  const nodeB = createNode(modB);
+  const nodeC = createNode(modC);
+  const nodes = [nodeA, nodeB, nodeC];
+
+  it('returns true for compatible nodes', () => {
+    const connection = { source: nodeA.id, target: nodeB.id } as any;
+    expect(validateConnection(nodes, connection)).toBe(true);
+  });
+
+  it('returns false for incompatible nodes', () => {
+    const connection = { source: nodeA.id, target: nodeC.id } as any;
+    expect(validateConnection(nodes, connection)).toBe(false);
+  });
+
+  it('returns false for missing nodes', () => {
+    const connection = { source: 'missing', target: nodeC.id } as any;
+    expect(validateConnection(nodes, connection)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- enhance React Flow canvas with undo/redo and proper state updates
- attach dnd-kit droppable ref correctly
- extend unit tests for flow helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e292b9848325a74225fad6e69490