### PR TITLE
Improve module contract validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ Modules are TypeScript files under `modules/<name>/index.ts` exporting an object
 
 ```ts
 export interface ModuleMetadata {
-  name: string;
+  id: string;
   version: string;
-  description?: string;
+  name: string;
+  description: string;
+  inputs: string[];
+  outputs: string[];
+  uiSchema: Record<string, unknown>;
+  incompatible?: string[];
 }
 ```
 

--- a/modules/file-selector/index.ts
+++ b/modules/file-selector/index.ts
@@ -8,6 +8,7 @@ export interface FileSelectorModule {
   inputs: string[];
   outputs: string[];
   uiSchema: Record<string, unknown>;
+  incompatible?: string[];
   run: () => Promise<string[]>;
 }
 

--- a/modules/logger/index.ts
+++ b/modules/logger/index.ts
@@ -3,9 +3,12 @@ export interface LoggerOptions {
 }
 
 export default {
+  id: 'logger',
   name: 'logger',
   version: '1.0.0',
   description: 'Logs string input to console',
+  inputs: ['text'],
+  outputs: ['text'],
   uiSchema: {
     type: 'object',
     properties: {

--- a/modules/text-input/index.ts
+++ b/modules/text-input/index.ts
@@ -1,7 +1,10 @@
 export default {
+  id: 'text-input',
   name: 'text-input',
   version: '1.0.0',
   description: 'Free text entry module',
+  inputs: [],
+  outputs: ['text'],
   uiSchema: {
     type: 'object',
     properties: {

--- a/modules/validModule/index.ts
+++ b/modules/validModule/index.ts
@@ -1,5 +1,13 @@
 export default {
+  id: 'valid-module',
   name: 'valid-module',
   version: '1.0.0',
-  description: 'A valid module'
+  description: 'A valid module',
+  inputs: [],
+  outputs: [],
+  uiSchema: {
+    type: 'object',
+    properties: {},
+    required: []
+  }
 };

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,9 +15,14 @@ an object conforming to the `ModuleMetadata` interface:
 
 ```ts
 export interface ModuleMetadata {
-  name: string;
+  id: string;
   version: string;
-  description?: string;
+  name: string;
+  description: string;
+  inputs: string[];
+  outputs: string[];
+  uiSchema: Record<string, unknown>;
+  incompatible?: string[];
 }
 ```
 

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -3,7 +3,18 @@ import path from 'path';
 import type { ModuleMetadata } from './types';
 
 function isValidModule(obj: any): obj is ModuleMetadata {
-  return obj && typeof obj.name === 'string' && typeof obj.version === 'string';
+  return (
+    obj != null &&
+    typeof obj.id === 'string' &&
+    typeof obj.version === 'string' &&
+    typeof obj.name === 'string' &&
+    typeof obj.description === 'string' &&
+    Array.isArray(obj.inputs) && obj.inputs.every((i: any) => typeof i === 'string') &&
+    Array.isArray(obj.outputs) && obj.outputs.every((o: any) => typeof o === 'string') &&
+    obj.uiSchema && typeof obj.uiSchema === 'object' &&
+    (obj.incompatible === undefined ||
+      (Array.isArray(obj.incompatible) && obj.incompatible.every((i: any) => typeof i === 'string')))
+  );
 }
 
 export async function loadModules(): Promise<ModuleMetadata[]> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,34 @@
 export interface ModuleMetadata {
-  name: string;
+  /**
+   * Unique identifier for the module
+   */
+  id: string;
+  /**
+   * Semantic version of the module
+   */
   version: string;
-  description?: string;
+  /**
+   * Human readable name
+   */
+  name: string;
+  /**
+   * Short description of the module
+   */
+  description: string;
+  /**
+   * Types this module accepts as input
+   */
+  inputs: string[];
+  /**
+   * Types this module outputs
+   */
+  outputs: string[];
+  /**
+   * JSON schema describing the configuration UI
+   */
+  uiSchema: Record<string, unknown>;
+  /**
+   * Optional list of incompatible module ids
+   */
+  incompatible?: string[];
 }

--- a/packages/core/test/loadModules.test.ts
+++ b/packages/core/test/loadModules.test.ts
@@ -17,12 +17,32 @@ describe('loadModules', () => {
   it('loads valid modules', async () => {
     const modules = await loadModules();
     expect(modules.length).toBeGreaterThan(0);
-    expect(modules.some(m => m.name === 'valid-module')).toBe(true);
+    const valid = modules.find(m => m.id === 'valid-module');
+    expect(valid).toBeDefined();
+    expect(typeof valid?.uiSchema).toBe('object');
   });
 
   it('throws on invalid module', async () => {
     await fs.mkdir(invalidDir, { recursive: true });
-    await fs.writeFile(`${invalidDir}index.ts`, 'export default { broken: true };');
+    await fs.writeFile(`${invalidDir}index.ts`, 'export default { broken: true }');
+    await expect(loadModules()).rejects.toThrow();
+  });
+
+  it('throws when required fields are missing', async () => {
+    await fs.mkdir(invalidDir, { recursive: true });
+    await fs.writeFile(
+      `${invalidDir}index.ts`,
+      "export default { id: 'bad', version: '1.0.0' }"
+    );
+    await expect(loadModules()).rejects.toThrow();
+  });
+
+  it('throws when fields have wrong type', async () => {
+    await fs.mkdir(invalidDir, { recursive: true });
+    await fs.writeFile(
+      `${invalidDir}index.ts`,
+      "export default { id: 'bad', version: '1.0.0', name: 'bad', description: 'x', inputs: 'nope', outputs: [], uiSchema: {} }"
+    );
     await expect(loadModules()).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- extend `ModuleMetadata` with full contract details
- enforce validation of all required fields
- update existing module implementations
- document new contract in READMEs
- add more thorough loader tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684933949dc08325a5bfe12cebeefaba